### PR TITLE
fix error message and data to JSON conversion

### DIFF
--- a/magento2.js
+++ b/magento2.js
@@ -113,6 +113,11 @@ Magento2.prototype.request = function(method, url, urlParams, data, callback) {
     }).join('&');
   }
 
+  if (typeof(data) === 'string'){
+    console.log('WARNING! data parameter was passed as a string but a JSON object was expected.  Attempting to convert to JSON');
+    data = JSON.parse(data);
+  }
+
   totalUrl += url;
 
   if (urlParamString.length > 0) {
@@ -153,7 +158,7 @@ Magento2.prototype.request = function(method, url, urlParams, data, callback) {
               callback(null, JSON.parse(response));
             }
             else {
-              callback(response.message);
+              callback("Message: " + JSON.parse(response).message + " Parameters: " + JSON.stringify(JSON.parse(response).parameters));
             }
           });
         });


### PR DESCRIPTION
Fixed the response error as it was not converting the response to a JSON object before attempting to access properties.
Also added automatic conversion of the "data" parameter with a warning from a string to a JSON object since that is the expected data type.
line 161 could alternately be just callback(response); since response is a string, but this will also report back the entire Magento stack trace.